### PR TITLE
Update installation documentation for Debian/Ubuntu based systems

### DIFF
--- a/_pages/install/linux.md
+++ b/_pages/install/linux.md
@@ -23,20 +23,20 @@ The recommended way is to use our own [repo](https://apt.svtplay-dl.se/).
 
 ```bash
 # Add the PGP release keys:
-curl -s https://svtplay-dl.se/release-key.txt | sudo apt-key add -
+sudo curl -s https://svtplay-dl.se/release-key.txt --output /usr/share/keyrings/svtplay-dl.txt
 
 # Add the release channel to your APT sources:
 
-echo "deb https://apt.svtplay-dl.se/ svtplay-dl release" | sudo tee /etc/apt/sources.list.d/svtplay-dl.list
+echo "deb [signed-by=/usr/share/keyrings/svtplay-dl.txt] https://apt.svtplay-dl.se/ svtplay-dl release" | sudo tee /etc/apt/sources.list.d/svtplay-dl.list
 
 # Update and install svtplay-dl:
 
-sudo apt-get update
-sudo apt-get install svtplay-dl
+sudo apt update
+sudo apt install svtplay-dl
 
 # For postprocessing of video files, also install ffmpeg:
 
-sudo apt-get install ffmpeg
+sudo apt install ffmpeg
 ```
 
 ## Solus


### PR DESCRIPTION
This fixes the warning (below) on new Ubuntu and Debian systems.

`W: https://apt.svtplay-dl.se/dists/svtplay-dl/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.`